### PR TITLE
Fix for registration error

### DIFF
--- a/generators/app/templates/src/main/webapp/app/components/interceptor/_entity-audit.interceptor.js
+++ b/generators/app/templates/src/main/webapp/app/components/interceptor/_entity-audit.interceptor.js
@@ -10,7 +10,7 @@ angular.module('<%=angularAppName%>')
                 var obj = config.data;
                 var Principal = $injector.get('Principal');
                 Principal.identity().then(function(identity) {
-                    if (obj !== undefined && obj !== null && !(typeof obj === 'string' || obj instanceof String)) {
+                    if (obj !== undefined && obj !== null && identity !== null && !(typeof obj === 'string' || obj instanceof String)) {
                         if (config.method === 'POST') {
                             obj['createdBy'] = identity.login;
                         } else {


### PR DESCRIPTION
Entity audit broke down registration of new users. It tries to get identity of a new user that does not exist yet.
```
Error: identity is null
requestInterceptor.request/<@http://localhost:8080/scripts/components/interceptor/entity.audit.interceptor.js:15:29
```
Simplest way to fix this is to check identity for null values. New users are marked as created by anonymous.