### PR TITLE
Fix for broken tests

### DIFF
--- a/generators/app/templates/src/main/java/package/domain/_EntityAuditEvent.java
+++ b/generators/app/templates/src/main/java/package/domain/_EntityAuditEvent.java
@@ -41,6 +41,7 @@ public class EntityAuditEvent implements Serializable{
     @Column(name = "action", length = 20, nullable = false)
     private String action;
 
+    @Lob
     @Column(name = "entity_value")
     private String entityValue;
 

--- a/generators/app/templates/src/main/java/package/domain/_EntityAuditEvent.java
+++ b/generators/app/templates/src/main/java/package/domain/_EntityAuditEvent.java
@@ -23,7 +23,7 @@ public class EntityAuditEvent implements Serializable{
 
     private static final long serialVersionUID = 1L;
     <% if (databaseType == 'sql' && auditFramework === 'custom') { %>
-  	@Id
+    @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 


### PR DESCRIPTION
JHipster 2.27.2 & entity-audit 1.0.7 from npm.
Enabled entity audit broke tests with prod profile and SQL database type. Default test database is H2, but problem also persists in MySQL.

`Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'entityManagerFactory' defined in class path resource [org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaAutoConfiguration.class]: Invocation of init method failed; nested exception is org.hibernate.HibernateException: Wrong column type in PROJECT.PUBLIC.JHI_ENTITY_AUDIT_EVENT for column entity_value. Found: clob, expected: varchar(255)`

Using @Lob annotation fixes this issue (at least for H2 and MySQL - sorry, can't test with PostgreSQL and Oracle).