### PR TITLE
Removed adding of entityAuditInterceptor

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -182,8 +182,6 @@ module.exports = yeoman.Base.extend({
         this.copyFiles(files);
         jhipsterFunc.addChangelogToLiquibase(this.changelogDate + '_added_entity_EntityAuditEvent');
 
-        jhipsterFunc.addAngularJsInterceptor('entityAuditInterceptor');
-
         // add the new Listener to the 'AbstractAuditingEntity' class and add import
         if(!this.fs.read(this.javaDir + 'domain/AbstractAuditingEntity.java', {defaults: ''}).includes('EntityAuditEventListener.class')) {
           jhipsterFunc.replaceContent(this.javaDir + 'domain/AbstractAuditingEntity.java', 'AuditingEntityListener.class', '{AuditingEntityListener.class, EntityAuditEventListener.class}');


### PR DESCRIPTION
 `entityAuditInterceptor` was removed in [0cd3145](https://github.com/hipster-labs/generator-jhipster-entity-audit/commit/0cd31450d60733aad3b6aed3ad7e84a99888075f) but generator still tries to add it.