### PR TITLE
fix semver check error

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "chalk": "1.1.1",
     "glob": "^7.0.3",
     "semver": "5.1.0",
-    "generator-jhipster": "^3.6.0"
+    "generator-jhipster": "^4.0.0"
   },
   "devDependencies": {
     "gulp": "^3.9.0",


### PR DESCRIPTION
Error message is "I support only JHipster versions greater than ^3.6.0 ..."
In semver ^3.6.0 means: >=3.6.0 && <4.0.0
And as actually latest generator-jhipster-entity-audit needs >=4.0.0 version for correct functioning then doing upgrade.