### PR TITLE
Use instant and add cache config

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -176,6 +176,8 @@ module.exports = yeoman.Base.extend({
         }, this);
       };
       this.clientFramework = jhipsterVar.clientFramework;
+      this.hibernateCache = jhipsterVar.hibernateCache;
+      this.packageFolder = jhipsterVar.packageFolder;
     },
 
     writeBaseFiles : function () {
@@ -206,6 +208,9 @@ module.exports = yeoman.Base.extend({
         // remove the jsonIgnore on the audit fields so that the values can be passed
         jhipsterFunc.replaceContent(this.javaDir + 'domain/AbstractAuditingEntity.java', '\s*@JsonIgnore', '', true);
 
+        if (this.hibernateCache === 'ehcache') {
+          jhipsterFunc.addEntityToEhcache('EntityAuditEvent', [], this.packageName, this.packageFolder);
+        }
       } else {
 
         files = [

--- a/generators/app/templates/src/main/java/package/config/audit/_AsyncEntityAuditEventWriter.java
+++ b/generators/app/templates/src/main/java/package/config/audit/_AsyncEntityAuditEventWriter.java
@@ -9,7 +9,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
-import javax.inject.Inject;
 import java.io.IOException;
 import java.lang.reflect.Field;
 
@@ -22,11 +21,14 @@ public class AsyncEntityAuditEventWriter {
 
     private final Logger log = LoggerFactory.getLogger(AsyncEntityAuditEventWriter.class);
 
-    @Inject
-    private EntityAuditEventRepository auditingEntityRepository;
+    private final EntityAuditEventRepository auditingEntityRepository;
 
-    @Inject
-    private ObjectMapper objectMapper; //Jackson object mapper
+    private final ObjectMapper objectMapper; //Jackson object mapper
+
+    public AsyncEntityAuditEventWriter(EntityAuditEventRepository auditingEntityRepository, ObjectMapper objectMapper) {
+        this.auditingEntityRepository = auditingEntityRepository;
+        this.objectMapper = objectMapper;
+    }
 
     /**
      * Writes audit events to DB asynchronously in a new thread

--- a/generators/app/templates/src/main/java/package/domain/_EntityAuditEvent.java
+++ b/generators/app/templates/src/main/java/package/domain/_EntityAuditEvent.java
@@ -3,14 +3,14 @@ package <%=packageName%>.domain;
 <% if (databaseType === 'sql' && auditFramework === 'custom') { %>
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;<% } else if (auditFramework === 'javers') {%>
 import org.javers.core.metamodel.object.CdoSnapshot;
 import org.joda.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.ZonedDateTime;<% }%>
+import java.time.Instant;<% }%>
 import java.io.Serializable;
 import java.util.Objects;
 <% if (databaseType === 'sql' && auditFramework === 'custom') { %>
@@ -57,7 +57,7 @@ public class EntityAuditEvent implements Serializable{
 
     @NotNull
     @Column(name = "modified_date", nullable = false)
-    private ZonedDateTime modifiedDate;
+    private Instant modifiedDate;
     <% } else if (auditFramework === 'javers') { %>
     private String id;
 
@@ -73,7 +73,7 @@ public class EntityAuditEvent implements Serializable{
 
     private String modifiedBy;
 
-    private ZonedDateTime modifiedDate;
+    private Instant modifiedDate;
 
     public String getId() {
         return id;
@@ -147,11 +147,11 @@ public class EntityAuditEvent implements Serializable{
         this.modifiedBy = modifiedBy;
     }
 
-    public ZonedDateTime getModifiedDate() {
+    public Instant getModifiedDate() {
         return modifiedDate;
     }
 
-    public void setModifiedDate(ZonedDateTime modifiedDate) {
+    public void setModifiedDate(Instant modifiedDate) {
         this.modifiedDate = modifiedDate;
     }
 
@@ -226,14 +226,7 @@ public class EntityAuditEvent implements Serializable{
         }
         LocalDateTime localTime = snapshot.getCommitMetadata().getCommitDate();
 
-        ZonedDateTime modifyDate = ZonedDateTime.of(localTime.getYear(),
-          localTime.getMonthOfYear(),
-          localTime.getDayOfMonth(),
-          localTime.getHourOfDay(),
-          localTime.getMinuteOfHour(),
-          localTime.getSecondOfMinute(),
-          localTime.getMillisOfSecond(),
-          ZoneId.systemDefault());
+        Instant modifyDate = Instant.from(localTime);
 
         entityAuditEvent.setModifiedDate(modifyDate);
 

--- a/generators/app/templates/src/main/java/package/service/dto/_AbstractAuditingDTO.java
+++ b/generators/app/templates/src/main/java/package/service/dto/_AbstractAuditingDTO.java
@@ -1,7 +1,7 @@
 package <%=packageName%>.service.dto;
 
 import java.io.Serializable;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import org.springframework.data.annotation.ReadOnlyProperty;
 
 /**
@@ -16,11 +16,11 @@ public abstract class AbstractAuditingDTO implements Serializable {
     private String createdBy;
 
     @ReadOnlyProperty
-    private ZonedDateTime createdDate = ZonedDateTime.now();
+    private Instant createdDate = Instant.now();
 
     private String lastModifiedBy;
 
-    private ZonedDateTime lastModifiedDate = ZonedDateTime.now();
+    private Instant lastModifiedDate = Instant.now();
 
     public String getCreatedBy() {
         return createdBy;
@@ -30,11 +30,11 @@ public abstract class AbstractAuditingDTO implements Serializable {
         this.createdBy = createdBy;
     }
 
-    public ZonedDateTime getCreatedDate() {
+    public Instant getCreatedDate() {
         return createdDate;
     }
 
-    public void setCreatedDate(ZonedDateTime createdDate) {
+    public void setCreatedDate(Instant createdDate) {
         this.createdDate = createdDate;
     }
 
@@ -46,11 +46,11 @@ public abstract class AbstractAuditingDTO implements Serializable {
         this.lastModifiedBy = lastModifiedBy;
     }
 
-    public ZonedDateTime getLastModifiedDate() {
+    public Instant getLastModifiedDate() {
         return lastModifiedDate;
     }
 
-    public void setLastModifiedDate(ZonedDateTime lastModifiedDate) {
+    public void setLastModifiedDate(Instant lastModifiedDate) {
         this.lastModifiedDate = lastModifiedDate;
     }
 }

--- a/generators/app/templates/src/main/java/package/web/rest/_EntityAuditResource.java
+++ b/generators/app/templates/src/main/java/package/web/rest/_EntityAuditResource.java
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.security.access.annotation.Secured;
 import com.codahale.metrics.annotation.Timed;
 
-import javax.inject.Inject;
 import java.net.URISyntaxException;
 import java.util.List;
 import javax.transaction.Transactional;
@@ -35,8 +34,11 @@ public class EntityAuditResource {
 
     private final Logger log = LoggerFactory.getLogger(EntityAuditResource.class);
 
-    @Inject
-    private EntityAuditEventRepository entityAuditEventRepository;
+    private final EntityAuditEventRepository entityAuditEventRepository;
+
+    public EntityAuditResource(EntityAuditEventRepository entityAuditEventRepository) {
+        this.entityAuditEventRepository = entityAuditEventRepository;
+    }
 
     /**
      * fetches all the audited entity types

--- a/generators/app/templates/src/main/java/package/web/rest/_JaversEntityAuditResource.java
+++ b/generators/app/templates/src/main/java/package/web/rest/_JaversEntityAuditResource.java
@@ -23,7 +23,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.security.access.annotation.Secured;
 import com.codahale.metrics.annotation.Timed;
 
-import javax.inject.Inject;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.ArrayList;
@@ -38,9 +37,11 @@ public class JaversEntityAuditResource {
 
     private final Logger log = LoggerFactory.getLogger(JaversEntityAuditResource.class);
 
-    @Inject
-    private Javers javers;
+    private final Javers javers;
 
+    public JaversEntityAuditResource(Javers javers) {
+        this.javers = javers;
+    }
 
     /**
      * fetches all the audited entity types


### PR DESCRIPTION
- use `java.time.Instant` instead of ZonedDateTime to be compatible with https://github.com/jhipster/generator-jhipster/commit/1cb14a8872c4977f74451b9be8fb85a51984feb1 (#61)
- remove `javax.inject.Inject` usage (#61) 
- add `EntityAuditEvent` to cache config if ehcache is used (#60)