### PR TITLE
Javers support fix; close #70

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -275,17 +275,17 @@ module.exports = JhipsterAuditGenerator.extend({
         // add required third party dependencies
         if (this.buildTool === 'maven') {
           if (this.databaseType === 'mongodb') {
-            this.addMavenDependency('org.javers', 'javers-spring-boot-starter-mongo', '2.3.0', '<scope>compile</scope>');
-            this.addMavenDependency('org.mongodb', 'mongo-java-driver', '3.2.2', '<scope>compile</scope>');
+            this.addMavenDependency('org.javers', 'javers-spring-boot-starter-mongo', '3.5.0', '<scope>compile</scope>');
+            this.addMavenDependency('org.mongodb', 'mongo-java-driver', '3.4.2', '<scope>compile</scope>');
           } else if (this.databaseType === 'sql') {
-            this.addMavenDependency('org.javers', 'javers-spring-boot-starter-sql', '2.3.0', '<scope>compile</scope>');
+            this.addMavenDependency('org.javers', 'javers-spring-boot-starter-sql', '3.5.0', '<scope>compile</scope>');
           }
         } else if (this.buildTool === 'gradle') {
           if (this.databaseType === 'mongodb') {
-            this.addGradleDependency('compile', 'org.javers', 'javers-spring-boot-starter-mongo', '2.3.0');
-            this.addGradleDependency('compile', 'org.mongodb', 'mongo-java-driver', '3.2.2');
+            this.addGradleDependency('compile', 'org.javers', 'javers-spring-boot-starter-mongo', '3.5.0');
+            this.addGradleDependency('compile', 'org.mongodb', 'mongo-java-driver', '3.4.2');
           } else if (this.databaseType === 'sql') {
-            this.addGradleDependency('compile', 'org.javers', 'javers-spring-boot-starter-sql', '2.3.0');
+            this.addGradleDependency('compile', 'org.javers', 'javers-spring-boot-starter-sql', '3.5.0');
           }
         }
       }

--- a/generators/app/templates/src/main/java/package/domain/_EntityAuditEvent.java
+++ b/generators/app/templates/src/main/java/package/domain/_EntityAuditEvent.java
@@ -8,8 +8,8 @@ import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;<% } else if (auditFramework === 'javers') {%>
 import org.javers.core.metamodel.object.CdoSnapshot;
-import org.joda.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.Instant;<% }%>
 import java.io.Serializable;
 import java.util.Objects;
@@ -208,15 +208,15 @@ public class EntityAuditEvent implements Serializable{
         entityAuditEvent.setEntityId(snapshot.getGlobalId().value().split("/")[1]);
         entityAuditEvent.setModifiedBy(snapshot.getCommitMetadata().getAuthor());
 
-        if (snapshot.getState().getProperties().size() > 0) {
+        if (snapshot.getState().getPropertyNames().size() > 0) {
             int count = 0;
             StringBuilder sb = new StringBuilder("{");
 
-            for (String s:snapshot.getState().getProperties()) {
+            for (String s:snapshot.getState().getPropertyNames()) {
                 count++;
                 Object propertyValue = snapshot.getPropertyValue(s);
                 sb.append("\"" + s + "\": \"" + propertyValue + "\"");
-                if (count < snapshot.getState().getProperties().size()) {
+                if (count < snapshot.getState().getPropertyNames().size()) {
                   sb.append(",");
                 }
              }
@@ -226,7 +226,7 @@ public class EntityAuditEvent implements Serializable{
         }
         LocalDateTime localTime = snapshot.getCommitMetadata().getCommitDate();
 
-        Instant modifyDate = Instant.from(localTime);
+        Instant modifyDate = localTime.toInstant(ZoneOffset.UTC);
 
         entityAuditEvent.setModifiedDate(modifyDate);
 

--- a/generators/app/templates/src/main/java/package/web/rest/_JaversEntityAuditResource.java
+++ b/generators/app/templates/src/main/java/package/web/rest/_JaversEntityAuditResource.java
@@ -55,7 +55,7 @@ public class JaversEntityAuditResource {
     @Secured(AuthoritiesConstants.ADMIN)
     public List<String> getAuditedEntities() {
 
-      return Arrays.asList(<%- auditedEntities %>);
+      return Arrays.asList(<%- entitiesToUpdate.map(e => `"${e}"`).join(', ') %>);
     }
 
     /**

--- a/generators/utils.js
+++ b/generators/utils.js
@@ -16,7 +16,7 @@ const changeset = (changelogDate, entityTableName) =>
         </addColumn>
     </changeSet>`;
 
-const updateEntityAudit = function (entityName, entityData, javaDir, resourceDir, updateIndex) {
+const updateEntityAudit = function (entityName, entityData, javaDir, resourceDir) {
   if (this.auditFramework === 'custom') {
     // extend entity with AbstractAuditingEntity
     if (!this.fs.read(`${javaDir}domain/${entityName}.java`, {

--- a/generators/utils.js
+++ b/generators/utils.js
@@ -51,21 +51,6 @@ const updateEntityAudit = function (entityName, entityData, javaDir, resourceDir
         this.replaceContent(`${javaDir}repository/${entityName}Repository.java`, `public interface ${entityName}Repository`, `@JaversSpringDataAuditable\npublic interface ${entityName}Repository`);
         this.replaceContent(`${javaDir}repository/${entityName}Repository.java`, `domain.${entityName};`, `domain.${entityName};\nimport org.javers.spring.annotation.JaversSpringDataAuditable;`);
       }
-      // update the list of audited entities if audit page is available
-      if (updateIndex && this.fs.exists(`${javaDir}web/rest/JaversEntityAuditResource.java`)) {
-        this.existingEntities.push(entityName);
-        this.auditedEntities = [];
-
-        this.existingEntities.forEach((entityName) => {
-          this.auditedEntities.push(`'${entityName}'`);
-        });
-
-        const files = [{
-          from: `${this.javaTemplateDir}/web/rest/_JaversEntityAuditResource.java`,
-          to: `${javaDir}web/rest/JaversEntityAuditResource.java`
-        }];
-        this.copyFiles(files);
-      }
     }
   }
 };


### PR DESCRIPTION
Update Javers support to work after recent refactoring by making the template use `entitiesToUpdate` array directly instead of its copy which wasn't updated anymore.

This also required an update to Javers 3.5.0 in order to bring in support for new `java.time` classes.
