### PR TITLE
fix Javers support

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -14,8 +14,6 @@ const JhipsterAuditGenerator = generator.extend({});
 util.inherits(JhipsterAuditGenerator, BaseGenerator);
 
 
-const TPL = 'template';
-
 module.exports = JhipsterAuditGenerator.extend({
 
   initializing: {
@@ -190,13 +188,6 @@ module.exports = JhipsterAuditGenerator.extend({
       this.javaDir = `${jhipsterConstants.SERVER_MAIN_SRC_DIR + this.packageFolder}/`;
       this.resourceDir = jhipsterConstants.SERVER_MAIN_RES_DIR;
       this.interpolateRegex = jhipsterConstants.INTERPOLATE_REGEX;
-      this.copyFiles = (files) => {
-        files.forEach((file) => {
-          this.copyTemplate(file.from, file.to, file.type ? file.type : TPL, this, file.interpolate ? {
-            interpolate: file.interpolate
-          } : undefined);
-        });
-      };
     },
 
     writeBaseFiles() {
@@ -237,7 +228,7 @@ module.exports = JhipsterAuditGenerator.extend({
           interpolate: this.interpolateRegex
         }
         ];
-        this.copyFiles(files);
+        genUtils.copyFiles(this, files);
         this.addChangelogToLiquibase(`${this.changelogDate}_added_entity_EntityAuditEvent`);
 
         // add the new Listener to the 'AbstractAuditingEntity' class and add import
@@ -271,7 +262,7 @@ module.exports = JhipsterAuditGenerator.extend({
         }
         ];
 
-        this.copyFiles(files);
+        genUtils.copyFiles(this, files);
         // add required third party dependencies
         if (this.buildTool === 'maven') {
           if (this.databaseType === 'mongodb') {
@@ -359,7 +350,7 @@ module.exports = JhipsterAuditGenerator.extend({
             });
           });
         }
-        this.copyFiles(files);
+        genUtils.copyFiles(this, files);
         // add bower dependency required
         this.addBowerDependency('angular-object-diff', '1.0.3');
         this.addAngularJsModule('ds.objectDiff');

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -293,7 +293,16 @@ module.exports = JhipsterAuditGenerator.extend({
         let jsonObj = null;
 
         this.entitiesToUpdate.forEach((entityName) => {
-          jsonObj = this.fs.readJSON(`.jhipster/${entityName}.json`);
+          const entityFile = `.jhipster/${entityName}.json`;
+          jsonObj = this.fs.readJSON(entityFile);
+
+          // flag this entity as audited so the :entity subgenerator
+          // can pick up all audited entities
+          // technically this is only needed for Javers, as the custom
+          // framework obtains this list at runtime using
+          // `EntityAuditEventRepository.findAllEntityTypes`;
+          this.updateEntityConfig(entityFile, 'enableEntityAudit', true);
+
           genUtils.updateEntityAudit.call(this, entityName, jsonObj, this.javaDir, this.resourceDir);
         });
       }

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -275,17 +275,17 @@ module.exports = JhipsterAuditGenerator.extend({
         // add required third party dependencies
         if (this.buildTool === 'maven') {
           if (this.databaseType === 'mongodb') {
-            this.addMavenDependency('org.javers', 'javers-spring-boot-starter-mongo', '2.3.0', '<scope>compile</scope>');
-            this.addMavenDependency('org.mongodb', 'mongo-java-driver', '3.2.2', '<scope>compile</scope>');
+            this.addMavenDependency('org.javers', 'javers-spring-boot-starter-mongo', '3.5.0', '<scope>compile</scope>');
+            this.addMavenDependency('org.mongodb', 'mongo-java-driver', '3.4.2', '<scope>compile</scope>');
           } else if (this.databaseType === 'sql') {
-            this.addMavenDependency('org.javers', 'javers-spring-boot-starter-sql', '2.3.0', '<scope>compile</scope>');
+            this.addMavenDependency('org.javers', 'javers-spring-boot-starter-sql', '3.5.0', '<scope>compile</scope>');
           }
         } else if (this.buildTool === 'gradle') {
           if (this.databaseType === 'mongodb') {
-            this.addGradleDependency('compile', 'org.javers', 'javers-spring-boot-starter-mongo', '2.3.0');
-            this.addGradleDependency('compile', 'org.mongodb', 'mongo-java-driver', '3.2.2');
+            this.addGradleDependency('compile', 'org.javers', 'javers-spring-boot-starter-mongo', '3.5.0');
+            this.addGradleDependency('compile', 'org.mongodb', 'mongo-java-driver', '3.4.2');
           } else if (this.databaseType === 'sql') {
-            this.addGradleDependency('compile', 'org.javers', 'javers-spring-boot-starter-sql', '2.3.0');
+            this.addGradleDependency('compile', 'org.javers', 'javers-spring-boot-starter-sql', '3.5.0');
           }
         }
       }

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -110,7 +110,7 @@ module.exports = JhipsterAuditGenerator.extend({
     }, {
       when: response => response.updateType !== 'all',
       type: 'checkbox',
-      name: 'entitiesToUpdate',
+      name: 'auditedEntities',
       message: 'Please choose the entities to be audited',
       choices: this.existingEntityChoices,
       default: 'none'
@@ -147,7 +147,7 @@ module.exports = JhipsterAuditGenerator.extend({
         this.auditFramework = props.auditFramework;
         this.updateType = props.updateType;
         this.auditPage = props.auditPage;
-        this.entitiesToUpdate = props.entitiesToUpdate;
+        this.auditedEntities = props.auditedEntities;
         done();
       });
     }
@@ -285,14 +285,14 @@ module.exports = JhipsterAuditGenerator.extend({
     updateEntityFiles() {
       // Update existing entities to enable audit
       if (this.updateType === 'all') {
-        this.entitiesToUpdate = this.existingEntities;
+        this.auditedEntities = this.existingEntities;
       }
-      if (this.entitiesToUpdate && this.entitiesToUpdate.length > 0 && this.entitiesToUpdate !== 'none') {
-        this.log(`\n${chalk.bold.green('I\'m Updating selected entities ')}${chalk.bold.yellow(this.entitiesToUpdate)}`);
+      if (this.auditedEntities && this.auditedEntities.length > 0 && this.auditedEntities !== 'none') {
+        this.log(`\n${chalk.bold.green('I\'m Updating selected entities ')}${chalk.bold.yellow(this.auditedEntities)}`);
         this.log(`\n${chalk.bold.yellow('Make sure these classes does not extend any other class to avoid any errors during compilation.')}`);
         let jsonObj = null;
 
-        this.entitiesToUpdate.forEach((entityName) => {
+        this.auditedEntities.forEach((entityName) => {
           const entityFile = `.jhipster/${entityName}.json`;
           jsonObj = this.fs.readJSON(entityFile);
 

--- a/generators/app/templates/src/main/java/package/domain/_EntityAuditEvent.java
+++ b/generators/app/templates/src/main/java/package/domain/_EntityAuditEvent.java
@@ -8,8 +8,8 @@ import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;<% } else if (auditFramework === 'javers') {%>
 import org.javers.core.metamodel.object.CdoSnapshot;
-import org.joda.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.Instant;<% }%>
 import java.io.Serializable;
 import java.util.Objects;
@@ -208,15 +208,15 @@ public class EntityAuditEvent implements Serializable{
         entityAuditEvent.setEntityId(snapshot.getGlobalId().value().split("/")[1]);
         entityAuditEvent.setModifiedBy(snapshot.getCommitMetadata().getAuthor());
 
-        if (snapshot.getState().getProperties().size() > 0) {
+        if (snapshot.getState().getPropertyNames().size() > 0) {
             int count = 0;
             StringBuilder sb = new StringBuilder("{");
 
-            for (String s:snapshot.getState().getProperties()) {
+            for (String s:snapshot.getState().getPropertyNames()) {
                 count++;
                 Object propertyValue = snapshot.getPropertyValue(s);
                 sb.append("\"" + s + "\": \"" + propertyValue + "\"");
-                if (count < snapshot.getState().getProperties().size()) {
+                if (count < snapshot.getState().getPropertyNames().size()) {
                   sb.append(",");
                 }
              }
@@ -226,7 +226,7 @@ public class EntityAuditEvent implements Serializable{
         }
         LocalDateTime localTime = snapshot.getCommitMetadata().getCommitDate();
 
-        Instant modifyDate = Instant.from(localTime);
+        Instant modifyDate = localTime.toInstant(ZoneOffset.UTC);
 
         entityAuditEvent.setModifiedDate(modifyDate);
 

--- a/generators/app/templates/src/main/java/package/web/rest/_JaversEntityAuditResource.java
+++ b/generators/app/templates/src/main/java/package/web/rest/_JaversEntityAuditResource.java
@@ -55,7 +55,7 @@ public class JaversEntityAuditResource {
     @Secured(AuthoritiesConstants.ADMIN)
     public List<String> getAuditedEntities() {
 
-      return Arrays.asList(<%- auditedEntities %>);
+      return Arrays.asList(<%- auditedEntities.map(e => `"${e}"`).join(', ') %>);
     }
 
     /**

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -42,22 +42,11 @@ module.exports = JhipsterAuditEntityGenerator.extend({
       }
     },
 
-    getEntitityNames() {
-      const existingEntities = [];
-      let existingEntityNames = [];
-      try {
-        existingEntityNames = fs.readdirSync('.jhipster');
-      } catch (e) {
-        this.log(`${chalk.red.bold('ERROR!')} Could not read entities, you might not have generated any entities yet. I will continue to install audit files, entities will not be updated...\n`);
-      }
-
-      existingEntityNames.forEach((entry) => {
-        if (entry.indexOf('.json') !== -1) {
-          const entityName = entry.replace('.json', '');
-          existingEntities.push(entityName);
-        }
-      });
-      this.existingEntities = existingEntities;
+    getAuditedEntities() {
+      this.auditedEntities = this.getExistingEntities()
+        .filter(entity => entity.definition.enableEntityAudit)
+        .map(entity => entity.name);
+      console.log('auditedEntities:', this.auditedEntities);
     }
   },
 
@@ -92,6 +81,9 @@ module.exports = JhipsterAuditEntityGenerator.extend({
       // To access props later use this.props.someOption;
       this.enableAudit = props.enableAudit;
       this.auditFramework = this.config.get('auditFramework');
+      if (this.enableAudit && !this.auditedEntities.includes(entityName)) {
+        this.auditedEntities.push(entityName);
+      }
       done();
     });
   },

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const util = require('util');
 const chalk = require('chalk');
 const generator = require('yeoman-generator');
@@ -49,7 +48,6 @@ module.exports = JhipsterAuditEntityGenerator.extend({
       this.auditedEntities = this.getExistingEntities()
         .filter(entity => entity.definition.enableEntityAudit)
         .map(entity => entity.name);
-      console.log('auditedEntities:', this.auditedEntities);
     }
   },
 

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -21,6 +21,9 @@ module.exports = JhipsterAuditEntityGenerator.extend({
         this.error('Can\'t read .yo-rc.json');
       }
     },
+    setSource() {
+      this.sourceRoot(`${this.sourceRoot()}/../../app/templates`);
+    },
     checkDBType() {
       if (this.jhAppConfig.databaseType !== 'sql' && this.jhAppConfig.databaseType !== 'mongodb') {
         // exit if DB type is not SQL or MongoDB

--- a/generators/utils.js
+++ b/generators/utils.js
@@ -62,15 +62,12 @@ const updateEntityAudit = function (entityName, entityData, javaDir, resourceDir
         this.replaceContent(`${javaDir}repository/${entityName}Repository.java`, `public interface ${entityName}Repository`, `@JaversSpringDataAuditable\npublic interface ${entityName}Repository`);
         this.replaceContent(`${javaDir}repository/${entityName}Repository.java`, `domain.${entityName};`, `domain.${entityName};\nimport org.javers.spring.annotation.JaversSpringDataAuditable;`);
       }
-      // update the list of audited entities if audit page is available
+
+      // this is used from :entity subgenerator to update the list of
+      // audited entities (if audit page available) in `#getAuditedEntities`
+      // method in `JaversEntityAuditResource` class, in case that list
+      // has changed after running the generator
       if (updateIndex && this.fs.exists(`${javaDir}web/rest/JaversEntityAuditResource.java`)) {
-        this.existingEntities.push(entityName);
-        this.auditedEntities = [];
-
-        this.existingEntities.forEach((entityName) => {
-          this.auditedEntities.push(`'${entityName}'`);
-        });
-
         const files = [{
           from: `${this.javaTemplateDir}/web/rest/_JaversEntityAuditResource.java`,
           to: `${javaDir}web/rest/JaversEntityAuditResource.java`

--- a/generators/utils.js
+++ b/generators/utils.js
@@ -1,5 +1,8 @@
 const glob = require('glob');
 
+
+const TPL = 'template';
+
 const changeset = (changelogDate, entityTableName) =>
 `
     <!-- Added the entity audit columns -->
@@ -15,6 +18,14 @@ const changeset = (changelogDate, entityTableName) =>
             <column name="last_modified_date" type="timestamp"/>
         </addColumn>
     </changeSet>`;
+
+const copyFiles = (gen, files) => {
+  files.forEach((file) => {
+    gen.copyTemplate(file.from, file.to, file.type ? file.type : TPL, gen, file.interpolate ? {
+      interpolate: file.interpolate
+    } : undefined);
+  });
+};
 
 const updateEntityAudit = function (entityName, entityData, javaDir, resourceDir, updateIndex) {
   if (this.auditFramework === 'custom') {
@@ -64,7 +75,7 @@ const updateEntityAudit = function (entityName, entityData, javaDir, resourceDir
           from: `${this.javaTemplateDir}/web/rest/_JaversEntityAuditResource.java`,
           to: `${javaDir}web/rest/JaversEntityAuditResource.java`
         }];
-        this.copyFiles(files);
+        copyFiles(this, files);
       }
     }
   }
@@ -72,5 +83,6 @@ const updateEntityAudit = function (entityName, entityData, javaDir, resourceDir
 
 module.exports = {
   changeset,
+  copyFiles,
   updateEntityAudit
 };


### PR DESCRIPTION
Update Javers support to work after recent refactoring by making both the main generator and the :entity subgenerator populate and update `auditedEntities` array which is used in the template.

Minor refactoring:

- move `copyFiles` to `utils.js` for reusability
- rename `entitiesToUpdate` in main generator to `auditedEntities` to match the variable name used in :entity subgenerator and the `JaversEntityAuditResource` template

This also required an update to Javers 3.5.0 in order to bring in support for new `java.time` classes. Supersedes #58 

Fixes #70 
