### PR TITLE
use correct method for getting angularXAppName

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -170,7 +170,7 @@ module.exports = class extends BaseGenerator {
         this.cacheProvider = this.jhAppConfig.cacheProvider;
         // use function in generator-base.js from generator-jhipster
         this.angularAppName = this.getAngularAppName();
-        this.angular2AppName = this.getAngularAppName();
+        this.angularXAppName = this.getAngularXAppName();
         this.changelogDate = this.dateFormatForLiquibase();
         this.jhiPrefix = this.jhAppConfig.jhiPrefix;
         // if changelogDate for entity audit already exists then use this existing changelogDate

--- a/generators/app/templates/src/main/webapp/angular/app/admin/entity-audit/_entity-audit.module.ts
+++ b/generators/app/templates/src/main/webapp/angular/app/admin/entity-audit/_entity-audit.module.ts
@@ -2,7 +2,7 @@ import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { DiffMatchPatchModule } from 'ng-diff-match-patch';
 
-import { <%=angular2AppName%>SharedModule } from '../../shared';
+import { <%=angularXAppName%>SharedModule } from '../../shared';
 import { EntityAuditRoutingModule } from './entity-audit-routing.module';
 import { EntityAuditComponent } from './entity-audit.component';
 import { EntityAuditModalComponent } from './entity-audit-modal.component';
@@ -11,7 +11,7 @@ import { EntityAuditService } from './entity-audit.service';
 @NgModule({
     imports: [
         CommonModule,
-        <%=angular2AppName%>SharedModule,
+        <%=angularXAppName%>SharedModule,
         DiffMatchPatchModule,
         EntityAuditRoutingModule
     ],


### PR DESCRIPTION
The recent PR used the wrong method (which adds `App` to the end), this matches the main generator's export of SharedModule

related to #94 and #96 
