### PR TITLE
Various fixes and upgrades

### DIFF
--- a/generators/app/templates/src/main/java/package/domain/_EntityAuditEvent.java
+++ b/generators/app/templates/src/main/java/package/domain/_EntityAuditEvent.java
@@ -15,7 +15,7 @@ import java.io.Serializable;
 import java.util.Objects;
 <% if (databaseType === 'sql' && auditFramework === 'custom') { %>
 @Entity
-@Table(name = "jhi_entity_audit_event")
+@Table(name = "<%= jhiTablePrefix %>_entity_audit_event")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)<% } %>
 public class EntityAuditEvent implements Serializable{
 

--- a/generators/app/templates/src/main/resources/config/liquibase/changelog/_EntityAuditEvent.xml
+++ b/generators/app/templates/src/main/resources/config/liquibase/changelog/_EntityAuditEvent.xml
@@ -13,7 +13,7 @@
         Added the entity EntityAuditEvent.
     -->
     <changeSet id="<%= changelogDate %>" author="jhipster">
-        <createTable tableName="jhi_entity_audit_event">
+        <createTable tableName="<%= jhiTablePrefix %>_entity_audit_event">
             <column name="id" type="bigint" <%_ if (isAutoIncrementDB) { %> autoIncrement="${autoIncrement}" <%_ } %>>
                 <constraints primaryKey="true" nullable="false"/>
             </column>
@@ -34,14 +34,14 @@
             </column>
         </createTable>
         <createIndex indexName="idx_entity_audit_event_entity_id"
-            tableName="jhi_entity_audit_event">
+            tableName="<%= jhiTablePrefix %>_entity_audit_event">
             <column name="entity_id" type="bigint"/>
         </createIndex>
         <createIndex indexName="idx_entity_audit_event_entity_type"
-            tableName="jhi_entity_audit_event">
+            tableName="<%= jhiTablePrefix %>_entity_audit_event">
             <column name="entity_type" type="varchar(255)"/>
         </createIndex>
-        <dropDefaultValue tableName="jhi_entity_audit_event" columnName="modified_date" columnDataType="datetime"/>
+        <dropDefaultValue tableName="<%= jhiTablePrefix %>_entity_audit_event" columnName="modified_date" columnDataType="datetime"/>
         <!-- TODO add an archival job for the table -->
     </changeSet>
 </databaseChangeLog>

--- a/generators/app/templates/src/main/webapp/angular/app/admin/entity-audit/_entity-audit-modal.component.html
+++ b/generators/app/templates/src/main/webapp/angular/app/admin/entity-audit/_entity-audit-modal.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
     <h4 class="modal-title" jhiTranslate="entityAudit.detail.title">
-		    Audit Details
+        Audit Details
     </h4>
     <button
             <% if (enableTranslation) {
@@ -15,9 +15,9 @@
 </div>
 <div class="modal-body pad">
     <div>
-        <strong
+        <strong<% if (enableTranslation) { %>
                 jhiTranslate="entityAudit.detail.action"
-                [translateValues]="{ action: action }">
+                [translateValues]="{ action: action }"<% } %>>
             {{action}} action was performed on below data
         </strong>
         <br><br>

--- a/generators/app/templates/src/main/webapp/angular/app/admin/entity-audit/_entity-audit-modal.component.ts
+++ b/generators/app/templates/src/main/webapp/angular/app/admin/entity-audit/_entity-audit-modal.component.ts
@@ -6,7 +6,7 @@ import { EntityAuditService } from './entity-audit.service';
 import { EntityAuditEvent } from './entity-audit-event.model';
 
 @Component({
-    selector: '<%= jhiPrefix %>-entity-audit-modal',
+    selector: '<%= jhiPrefixDashed %>-entity-audit-modal',
     templateUrl: './entity-audit-modal.component.html',
     styles: [`
         /* NOTE: for now the /deep/ shadow-piercing descendant combinator is

--- a/generators/app/templates/src/main/webapp/angular/app/admin/entity-audit/_entity-audit.component.html
+++ b/generators/app/templates/src/main/webapp/angular/app/admin/entity-audit/_entity-audit.component.html
@@ -1,7 +1,7 @@
 <div>
     <h2 <% if (enableTranslation) { %> jhiTranslate="entityAudit.home.title" <% } %> >Entity Audit</h2>
 
-    <jhi-alert></jhi-alert>
+    <<%= jhiPrefixDashed %>-alert></<%= jhiPrefixDashed %>-alert>
 
     <div class="row">
         <div class="col-md-5">
@@ -33,7 +33,7 @@
 
                   <button class="btn btn-primary float-right" (click)="loadChanges()"
                           [disabled]="!auditEventForm.form.valid">
-                      <i class="fa fa-refresh"></i>&nbsp;
+                        <fa-icon icon="sync"></fa-icon>
                       <span <% if (enableTranslation) { %> jhiTranslate="entityAudit.home.loadChangeList" <% } %> >Load Change List</span>
                   </button>
                 </div>
@@ -43,8 +43,7 @@
 
     <div [hidden]="loading">
         <div class="table-responsive mt-2" *ngIf="audits">
-            <p *ngIf="selectedEntity" <% if (enableTranslation) { %> jhiTranslate="entityAudit.result.showInfo" <% } %>
-                   [translateValues]="{ limit: selectedLimit, entity: selectedEntity }">
+            <p *ngIf="selectedEntity"<% if (enableTranslation) { %> jhiTranslate="entityAudit.result.showInfo" [translateValues]="{ limit: selectedLimit, entity: selectedEntity }"<% } %>>
                 Last <strong>{{ selectedLimit }}</strong>
                 Changes for <strong>{{ selectedEntity }}</strong>
             </p>
@@ -88,7 +87,7 @@
                                 <% if (enableTranslation) { %> jhiTranslate="entityAudit.result.tableHeader.modifiedBy" <% } %> >
                             Modified By
                         </th>
-                        <th><i class="fa fa-eye"></i></th>
+                        <th><fa-icon icon="eye"></fa-icon></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -103,7 +102,7 @@
                             <button type="button" class="btn btn-info btn-xs"
                                     ngbTooltip="<% if (enableTranslation) { %>{{ 'entityAudit.result.tableBody.viewDetails' | translate }}<% } else { %>View Audit Change Details<% } %>"
                                     (click)=openChange(audit)>
-                                <i class="fa fa-eye"></i>
+                                <fa-icon icon="eye"></fa-icon>
                             </button>
                         </td>
                     </tr>

--- a/generators/app/templates/src/main/webapp/angular/app/admin/entity-audit/_entity-audit.component.ts
+++ b/generators/app/templates/src/main/webapp/angular/app/admin/entity-audit/_entity-audit.component.ts
@@ -7,7 +7,7 @@ import { EntityAuditEvent } from './entity-audit-event.model';
 import { EntityAuditModalComponent } from './entity-audit-modal.component';
 
 @Component({
-    selector: '<%= jhiPrefix %>-entity-audit',
+    selector: '<%= jhiPrefixDashed %>-entity-audit',
     templateUrl: './entity-audit.component.html',
     styles: [`
       .code {

--- a/generators/app/templates/src/main/webapp/angular/app/admin/entity-audit/_entity-audit.module.ts
+++ b/generators/app/templates/src/main/webapp/angular/app/admin/entity-audit/_entity-audit.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { DiffMatchPatchModule } from 'ng-diff-match-patch';
@@ -22,7 +22,6 @@ import { EntityAuditModalComponent } from './entity-audit-modal.component';
     // https://ng-bootstrap.github.io/#/components/modal/examples
     entryComponents: [
         EntityAuditModalComponent
-    ],
-    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    ]
 })
-export class EntityAuditModule { }
+export class EntityAuditModule {}

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -104,6 +104,7 @@ module.exports = class extends BaseGenerator {
         this.buildTool = this.jhAppConfig.buildTool;
         this.cacheProvider = this.jhAppConfig.cacheProvider;
         this.skipFakeData = this.jhAppConfig.skipFakeData;
+        this.skipServer = this.jhAppConfig.skipServer;
 
         // use function in generator-base.js from generator-jhipster
         this.angularAppName = this.getAngularAppName();
@@ -119,7 +120,9 @@ module.exports = class extends BaseGenerator {
           const entityName = this.entityConfig.entityClass;
           const jsonObj = (this.entityConfig.data === undefined ? { changelogDate: this.entityConfig.changelogDate, entityTableName: this.entityConfig.entityTableName } : this.entityConfig.data);
           this.changelogDate = jsonObj.changelogDate || this.dateFormatForLiquibase();
-          genUtils.updateEntityAudit.call(this, entityName, jsonObj, javaDir, resourceDir, true, this.skipFakeData);
+          if (!this.skipServer) {
+            genUtils.updateEntityAudit.call(this, entityName, jsonObj, javaDir, resourceDir, true, this.skipFakeData);
+          }
         }
       },
       updateConfig() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5577,9 +5577,9 @@
           "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
         },
         "resolve": {
-          "version": "1.14.2",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
-          "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz",
+          "integrity": "sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==",
           "requires": {
             "path-parse": "^1.0.6"
           }
@@ -7722,9 +7722,9 @@
       }
     },
     "yeoman-generator": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-4.4.0.tgz",
-      "integrity": "sha512-Z+eMdeyKuhbgnghhONh+xv+YztccJLgCQ8dOogq/9oLJAU/+D7oOdpLK/UryEoJQd5merJIDgCedVIxhtPsV2g==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-4.5.0.tgz",
+      "integrity": "sha512-70PbUilZnHV+wKIQ9cz9MmEnncaaW/1VjlXne4xBVlIFtfbt3ZZjE51jDdKgM8guIVx83aZt1exvMhqQSHqjpQ==",
       "requires": {
         "async": "^2.6.2",
         "chalk": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -22,11 +22,12 @@
     "Javers"
   ],
   "dependencies": {
-    "yeoman-generator": "4.4.0",
+    "yeoman-generator": "4.5.0",
     "yeoman-environment": "2.7.0",
     "shelljs": "0.8.3",
     "chalk": "3.0.0",
     "glob": "7.1.6",
+    "lodash": "4.17.15",
     "semver": "7.1.1",
     "generator-jhipster": ">=6.0.0"
   },


### PR DESCRIPTION
Made some fixes and enhancements:
* add `Prettier` transform to format generated code
* use `skipServer` and `skipServer` from config to generate front end only if not skipping client and back end only if not skipping server
* use `jhiPrefix` from config everywhere instead of using constant prefix `jhi` in some places
* removed some extra spaces from `jhipster-needle-add-admin-route` code so that in regeneration no double code any more
* fix #142 which occurred when i18n was not enabled
* fix #140 (icon cleaning in the admin menu is performed by jhipster/generator-jhipster#11210)
* remove `CUSTOM_ELEMENTS_SCHEMA` because no custom schema is used
* upgrade `yeoman-generator` dependency to version `4.5.0` to keep it in sync with `generator-jhipster`
* load user choices from config and don't ask again already answered questions
* save also `auditPage` variable to config
* registering also post app hook so that after app upgrade is entity audit support generated automatically

In `generator-jhipster` opened PR-s to better support this module:
* jhipster/generator-jhipster#11210 - if this is merged then icon appears in the admin menu for entity audit
* jhipster/generator-jhipster#11205 - if regenerating in Windows then don't add double code
