### PR TITLE
fix version of ng-diff-match-patch (2.0.6 to 3.0.1) for angular 9

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -418,7 +418,7 @@ module.exports = class extends BaseGenerator {
         if (!this.skipClient) {
           if (this.clientFramework === 'angularX') {
             // add dependency required for displaying diffs
-            this.addNpmDependency('ng-diff-match-patch', '2.0.6');
+            this.addNpmDependency('ng-diff-match-patch', '3.0.1');
             // based on BaseGenerator.addAdminToModule
             const adminModulePath = `${this.webappDir}app/admin/admin-routing.module.ts`;
             this.rewriteFile(


### PR DESCRIPTION
ng-diff-match-patch v.2.0.6 is not compatible with angular 9 Ivy and needs to be upgraded to latest version  3.0.1