### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ And looking for `(blueprint option: entity-audit)` options.
 To use an unreleased version, install it using git.
 
 ```bash
-npm install -g jhipster/generator-jhipster-entity-audit#main
+npm install -g hipster-labs/generator-jhipster-entity-audit#main
 jhipster --blueprints entity-audit --skip-jhipster-dependencies
 ```
 


### PR DESCRIPTION
The repo had been moved from `jhipster` to `hipster-labs` but there was a reference to the old one in the sample code to use an unreleased version. This is minor but I had to document it for other team members; might as well update it for everyone at the source.